### PR TITLE
优化一些细节：Deepseek 新模型激活 1M上下文 | 让插件关闭时在后台静默

### DIFF
--- a/houdini_agent/ui/ai_tab.py
+++ b/houdini_agent/ui/ai_tab.py
@@ -12,12 +12,15 @@ Agent loop, multi-turn tool calling, streaming UI
 """
 
 import json
+import logging
 import math
 import os
 import threading
 import time
 import uuid
 import queue
+
+logger = logging.getLogger(__name__)
 from datetime import datetime
 from pathlib import Path
 from typing import List, Dict, Any, Optional
@@ -5928,7 +5931,7 @@ SideFX Labs Node Usage Rules (MUST follow strictly):
                 return
             self._save_all_sessions()
         except Exception as e:
-            print(f"[Cache] 定期保存失败: {e}")
+            logger.warning("[Cache] 定期保存失败: %s", e)
     
     def _atexit_save(self):
         """Python 退出时的最后保存机会（atexit 回调）
@@ -5946,7 +5949,7 @@ SideFX Labs Node Usage Rules (MUST follow strictly):
                 return
             if not hasattr(self, '_sessions') or not self._sessions:
                 return
-            print(f"[Cache] atexit: 开始保存 (sessions={len(self._sessions)}, backup={len(getattr(self, '_tabs_backup', []))})")
+            logger.debug("[Cache] atexit: 开始保存 (sessions=%d, backup=%d)", len(self._sessions), len(getattr(self, '_tabs_backup', [])))
             try:
                 self._save_current_session_state()
             except (RuntimeError, AttributeError):
@@ -6046,7 +6049,7 @@ SideFX Labs Node Usage Rules (MUST follow strictly):
                 self._update_workspace_cache_info()
             return True
         except Exception as e:
-            print(f"[Cache] 自动保存失败: {e}")
+            logger.warning("[Cache] 自动保存失败: %s", e)
             return False
     
     def _update_manifest(self):
@@ -6091,7 +6094,7 @@ SideFX Labs Node Usage Rules (MUST follow strictly):
                 with open(manifest_file, 'w', encoding='utf-8') as f:
                     json.dump(manifest, f, ensure_ascii=False, indent=2)
         except Exception as e:
-            print(f"[Cache] 更新 manifest 失败: {e}")
+            logger.warning("[Cache] 更新 manifest 失败: %s", e)
 
     def _save_all_sessions(self) -> bool:
         """保存所有打开的会话到磁盘（关闭软件时调用）"""
@@ -6187,11 +6190,10 @@ SideFX Labs Node Usage Rules (MUST follow strictly):
                 json.dump(manifest, f, ensure_ascii=False, indent=2)
 
             self._sessions_saved = True
-            print(f"[Cache] 已保存 {len(manifest_tabs)} 个会话标签 (tabs_list={len(tabs_list)}, sessions={len(self._sessions)})")
+            logger.debug("[Cache] 已保存 %d 个会话标签 (tabs_list=%d, sessions=%d)", len(manifest_tabs), len(tabs_list), len(self._sessions))
             return True
-        except Exception as e:
-            print(f"[Cache] 保存所有会话失败: {e}")
-            import traceback; traceback.print_exc()
+        except Exception:
+            logger.exception("[Cache] 保存所有会话失败")
             return False
 
     def _restore_all_sessions(self) -> bool:
@@ -6369,12 +6371,11 @@ SideFX Labs Node Usage Rules (MUST follow strictly):
             self._update_token_stats_display()
             self._update_context_stats()
             self._sessions_restored = True  # 标记已恢复，防止重复
-            print(f"[Cache] 已恢复 {self.session_tabs.count()} 个会话标签")
+            logger.debug("[Cache] 已恢复 %d 个会话标签", self.session_tabs.count())
             return True
 
-        except Exception as e:
-            print(f"[Cache] 恢复多会话失败: {e}")
-            import traceback; traceback.print_exc()
+        except Exception:
+            logger.exception("[Cache] 恢复多会话失败")
             return False
 
     def _archive_cache(self) -> bool:

--- a/houdini_agent/ui/header.py
+++ b/houdini_agent/ui/header.py
@@ -102,8 +102,8 @@ class HeaderMixin:
         self._load_custom_provider_config()
         self._model_context_limits = {
             'qwen2.5:14b': 32000, 'qwen2.5:7b': 32000, 'llama3:8b': 8000, 'mistral:7b': 32000,
-            'deepseek-v4-flash': 128000, 'deepseek-v4-pro': 128000,
-            'deepseek-chat': 128000, 'deepseek-reasoner': 128000,
+            'deepseek-v4-flash': 1048576, 'deepseek-v4-pro': 1048576,
+            'deepseek-chat': 1048576, 'deepseek-reasoner': 1048576,
             'glm-4.7': 200000,
             'gpt-5.2': 128000,
             'gpt-5.3-codex': 200000,


### PR DESCRIPTION
 7ce0cfeded610fcc0d974fcb3195081a42fcc970 ：修改了 houdini_agent/ui/header.py 文件，将 DeepSeek 的新模型的上下文扩展到 1 M

<img width="217" height="67" alt="dwobbniz p4x" src="https://github.com/user-attachments/assets/81681259-dce4-44a1-b75e-f5df2314e97d" />

 2a4d12f43dd2b74669d5cf7e39c632e27e83c32f ： 修改了 houdini_agent/ui/ai_tab.py 文件，当关闭插件时，命令提示框也会每分钟弹出一次，提示项目已保存

这次修改将信息输出从命令行转移到日志中， 避免频繁弹出