### PR TITLE
fix: add startup breadcrumb logging for diagnosing show_tool() freezes

### DIFF
--- a/houdini_agent/main.py
+++ b/houdini_agent/main.py
@@ -48,21 +48,25 @@ _main_window = None
 
 def show_tool():
     global _main_window, MainWindow
-    
-    # 每次调用时强制重新加载模块
+
+    # 启动断点日志：用于诊断冷启动 freeze（参见 issue #9）。
+    # 用户报错时贴出 Houdini Python Shell 输出即可定位卡死阶段。
+    print("[Houdini Agent] Startup: reload_modules begin")
     _reload_modules()
-    
+    print("[Houdini Agent] Startup: reload_modules done")
+
     # ★ 重载后刷新 MainWindow 引用，避免使用旧类
     try:
         from houdini_agent.core.main_window import MainWindow as _MW
         MainWindow = _MW
     except Exception:
         pass
-    
+
     if not QtWidgets.QApplication.instance():
         app = QtWidgets.QApplication([])
     else:
         app = QtWidgets.QApplication.instance()
+    print("[Houdini Agent] Startup: QApplication ready")
 
     try:
         if _main_window is not None:
@@ -94,12 +98,17 @@ def show_tool():
         _main_window = None
 
     try:
+        print("[Houdini Agent] Startup: MainWindow() begin")
         _main_window = MainWindow()
+        print("[Houdini Agent] Startup: MainWindow() done, calling show()")
         _main_window.show()
         _main_window.raise_()
         _main_window.activateWindow()
+        print("[Houdini Agent] Startup: window shown")
         return _main_window
     except Exception as e:
+        import traceback
+        traceback.print_exc()
         QtWidgets.QMessageBox.critical(None, "Error", f"Failed to create Houdini Agent window:\n{e}", QtWidgets.QMessageBox.Ok)
         return None
 

--- a/houdini_agent/main.py
+++ b/houdini_agent/main.py
@@ -38,6 +38,8 @@ def _reload_modules():
         if mod_name in sys.modules:
             try:
                 import importlib
+                # 逐模块日志：若 reload 卡死，最后一条 "reload: X" 就是阻塞模块
+                print(f"[Houdini Agent] Startup: reload: {mod_name}")
                 importlib.reload(sys.modules[mod_name])
             except Exception:
                 pass
@@ -71,10 +73,12 @@ def show_tool():
     try:
         if _main_window is not None:
             if _main_window.isVisible():
+                print("[Houdini Agent] Startup: reusing existing visible window")
                 _main_window.raise_()
                 _main_window.activateWindow()
                 return _main_window
             else:
+                print("[Houdini Agent] Startup: cleaning up stale window")
                 # 清理旧实例的退出保存回调，防止覆盖新实例的数据
                 try:
                     import atexit as _atexit

--- a/houdini_agent/ui/ai_tab.py
+++ b/houdini_agent/ui/ai_tab.py
@@ -116,7 +116,9 @@ class AITab(
     
     def __init__(self, parent=None, workspace_dir: Optional[Path] = None):
         super().__init__(parent)
-        
+
+        # 启动断点日志：用于诊断冷启动 freeze（参见 issue #9）
+        print("[AITab] init: begin")
         self.client = AIClient()
         self.mcp = HoudiniMCP()
         self.mcp.set_stop_event(self.client._stop_event)  # 共享停止事件，使 shell/python 命令可被中断
@@ -271,14 +273,18 @@ class AITab(
         # 兼容旧引用
         self._system_prompt = self._system_prompt_think
         self._cached_optimized_system_prompt = self._cached_prompt_think
+        print("[AITab] init: _build_ui begin")
         self._build_ui()
+        print("[AITab] init: _build_ui done")
         self._wire_events()
         self._load_model_preference(restore_provider=True)  # 恢复上次使用的提供商和模型
         self._update_key_status()
         self._update_context_stats()
-        
+
         # ★ 启动时自动恢复上次的会话（从 sessions_manifest.json）
+        print("[AITab] init: _restore_all_sessions begin")
         self._restore_all_sessions()
+        print("[AITab] init: _restore_all_sessions done")
         
         self._destroyed = False
 

--- a/houdini_agent/ui/ai_tab.py
+++ b/houdini_agent/ui/ai_tab.py
@@ -928,38 +928,44 @@ SideFX Labs Node Usage Rules (MUST follow strictly):
     def _build_ui(self):
         # ---- 全局 QSS（由 ThemeEngine 从模板渲染） ----
         self.setObjectName("aiTab")
+        print("[AITab] _build_ui: theme")
         self._theme = ThemeEngine()
         self._theme.load_template(Path(__file__).parent / "style_template.qss")
         self._theme.load_preference()
         self.setStyleSheet(self._theme.render())
-        
+
         self.setMinimumWidth(320)
-        
+
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
         # 顶部设置栏
+        print("[AITab] _build_ui: header")
         header = self._build_header()
         layout.addWidget(header)
-        
+
         # 会话标签栏（多会话切换）
+        print("[AITab] _build_ui: session_tabs")
         session_tabs_bar = self._build_session_tabs()
         layout.addWidget(session_tabs_bar)
-        
+
         # 节点上下文栏
+        print("[AITab] _build_ui: node_context_bar")
         self.node_context_bar = NodeContextBar()
         self.node_context_bar.refreshRequested.connect(self._refresh_node_context)
         layout.addWidget(self.node_context_bar)
-        
+
         # 对话区域（多会话 - 使用 QStackedWidget）
         self.session_stack = QtWidgets.QStackedWidget()
         layout.addWidget(self.session_stack, 1)
-        
+
         # 创建第一个会话
+        print("[AITab] _build_ui: initial_session")
         self._create_initial_session()
 
         # 输入区域
+        print("[AITab] _build_ui: input_area")
         input_area = self._build_input_area()
         layout.addWidget(input_area)
 


### PR DESCRIPTION
## Summary

针对 #9：在 `main.py:show_tool()` 与 `AITab.__init__` 关键同步阶段加入 `[Houdini Agent] Startup: ...` / `[AITab] init: ...` 断点日志，并把 `MainWindow()` 构造异常的完整 traceback 打印到 Python Shell。

这样下次有人报告"启动卡死"时，用户只需在 `Windows → Python Shell` 打开后点 shelf tool，复制 Python Shell 输出即可定位到具体阻塞阶段：

- `reload_modules begin/done` — 模块热重载
- `QApplication ready` — Qt App 接管
- `MainWindow() begin/done` — 主窗口构造
- `AITab init: begin` — AITab 初始化
- `_build_ui begin/done` — UI 构建
- `_restore_all_sessions begin/done` — 历史会话恢复

如果某个 `begin` 之后再无输出，那一阶段就是阻塞源。

## Test plan
- [ ] 在 Houdini 中点 shelf tool，确认 Python Shell 按顺序打印所有 breadcrumb
- [ ] 正常窗口可见，行为与之前一致
- [ ] 如果 MainWindow 抛异常，能看到完整 traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)