### PR TITLE
test: 离线自动化测试系统 (pytest + CI)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: tests
+
+on:
+  push:
+    branches: [main, "release/**", "test/**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest requests
+
+      - name: Run offline test suite
+        run: pytest -ra -q

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,12 @@
+[pytest]
+# Houdini Agent 自动化测试配置
+# 只跑离线、无需 Houdini(hou)/无需联网的单元测试。
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -ra -q
+filterwarnings =
+    ignore::DeprecationWarning
+markers =
+    network: 需要真实网络的测试（默认不跑，用 -m network 显式开启）

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,39 @@
+# 自动化测试
+
+离线单元测试套件，**不需要 Houdini(hou)、不需要 Meshy API Key、不发任何网络请求**。
+
+## 运行
+
+```bash
+pip install pytest requests
+pytest                 # 跑全部
+pytest -q tests/test_meshy_telemetry.py    # 跑单个文件
+pytest -k telemetry    # 按名字筛
+```
+
+CI 在 push / PR 时自动跑（`.github/workflows/tests.yml`，Python 3.11–3.13）。
+
+## 隔离机制（见 `conftest.py`）
+
+- **路径隔离**：把 `shared.common_utils.get_repo_root` 重定向到临时目录，
+  所以 `config/` 与 `cache/` 的所有读写都落在 tmp，绝不碰真实文件。
+- **环境隔离**：每个用例前清掉 `MESHY_API_KEY` / `*_TELEMETRY_*` 等环境变量。
+- **禁网**：`telemetry_mod` 夹具把 `_post` 打桩为捕获器，并阻止后台上传线程。
+- **hou 桩**：提供最小 `hou` 模块兜底，防止意外 import 失败。
+
+## 覆盖范围
+
+| 文件 | 覆盖 |
+|------|------|
+| `test_shared_config.py` | 配置/历史读写、路径隔离 |
+| `test_meshy_config.py` | API Key 解析(env>ini)、脱敏、写入/清除 |
+| `test_meshy_schemas.py` | 工具 schema 合法性、工具集合自洽 |
+| `test_meshy_telemetry.py` | 事件构建、spool 往返、去重、opt-out、上传 |
+| `test_telemetry_server.py` | 后端去重入库、统计聚合、HTTP 端到端 |
+| `test_tool_registry.py` | 注册、模式访问控制、启用/禁用 |
+| `test_bridge_protocol.py` | `_diff_children`、BridgeClient JSON-lines 协议 |
+
+## 尚未覆盖（需 Houdini 环境，后续补）
+
+`hou.*` 节点操作、QML UI、Meshy 真实 API 调用、controller 信号流——这些依赖
+Houdini 运行时或外部服务，需用 Houdini 内的 `hython` 跑集成测试或引入 mock-hou 层。

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""
+全局测试夹具（pytest fixtures）。
+
+目标：让所有测试 **完全离线、与真实环境隔离**——
+  - 不读写真实的 <repo>/config、<repo>/cache（重定向到临时目录）
+  - 不依赖 Houdini 的 hou 模块（提供桩）
+  - 不发任何真实网络请求
+"""
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# 让 `import houdini_agent` / `import shared` 在 pytest 下可用（仓库根加入 sys.path）
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def isolated_paths(tmp_path, monkeypatch):
+    """把 shared.common_utils 的仓库根重定向到临时目录，
+    从而 config/cache 的所有读写都落在 tmp_path，绝不碰真实文件。
+
+    因为 get_config_dir() / get_cache_dir() 在调用时都经由 get_repo_root()，
+    只需打这一个点即可覆盖 load_config/save_config/get_cache_dir 全链路。"""
+    import shared.common_utils as cu
+    root = tmp_path / "repo"
+    (root / "config").mkdir(parents=True, exist_ok=True)
+    (root / "cache").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(cu, "get_repo_root", lambda *a, **k: str(root))
+    return root
+
+
+@pytest.fixture(autouse=True)
+def clean_meshy_env(monkeypatch):
+    """清掉可能影响 Meshy/埋点 行为的环境变量，保证每个测试从干净状态开始。"""
+    for var in ("MESHY_API_KEY", "DCC_AI_MESHY_API_KEY",
+                "HAGENT_TELEMETRY_OFF", "DCC_AI_TELEMETRY_OFF",
+                "HAGENT_TELEMETRY_URL", "DCC_AI_TELEMETRY_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _hou_stub():
+    """提供一个最小 hou 桩，避免任何意外 `import hou` 在收集阶段失败。
+    （被测的离线模块本身不需要 hou，这只是兜底。）"""
+    if "hou" not in sys.modules:
+        stub = types.ModuleType("hou")
+        sys.modules["hou"] = stub
+        created = True
+    else:
+        created = False
+    yield
+    if created:
+        sys.modules.pop("hou", None)
+
+
+@pytest.fixture
+def telemetry_mod(monkeypatch):
+    """返回隔离好的 telemetry 模块：
+    - requests 设为真值哨兵（让 is_enabled 不因测试环境缺 requests 而误判为关闭）
+    - _post 打桩为捕获器，绝不发真实请求
+    - 重置进程级状态（_seen_tasks / install id 缓存 / 上传线程）
+    - 阻止后台上传线程启动
+    """
+    from houdini_agent.meshy import telemetry as t
+
+    monkeypatch.setattr(t, "requests", object())     # 真值即可，_post 已被打桩
+    t._seen_tasks.clear()
+    t._install_id_cache[0] = None
+    t._uploader[0] = None
+    monkeypatch.setattr(t, "_ensure_uploader", lambda: None)
+
+    posted = []
+    monkeypatch.setattr(t, "_post", lambda url, events: (posted.append((url, list(events))) or True))
+    t.posted = posted        # 方便测试断言
+    return t

--- a/tests/test_bridge_protocol.py
+++ b/tests/test_bridge_protocol.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+"""桥接：纯函数 _diff_children + BridgeClient 的 JSON-lines 协议往返（mock server）。"""
+import json
+import socketserver
+import threading
+
+import pytest
+
+from houdini_agent.bridge.server import _diff_children
+from houdini_agent.bridge.client import BridgeClient
+
+
+# ---------------- _diff_children (纯函数) ----------------
+
+def test_diff_children_created():
+    before = {"/obj/a": {"name": "a"}}
+    after = {"/obj/a": {"name": "a"}, "/obj/b": {"name": "b"}}
+    d = _diff_children(before, after)
+    assert [c["name"] for c in d["created"]] == ["b"]
+    assert d["deleted"] == []
+
+
+def test_diff_children_deleted():
+    before = {"/obj/a": {"name": "a"}, "/obj/b": {"name": "b"}}
+    after = {"/obj/a": {"name": "a"}}
+    d = _diff_children(before, after)
+    assert [c["name"] for c in d["deleted"]] == ["b"]
+
+
+def test_diff_children_no_change_returns_none():
+    same = {"/obj/a": {"name": "a"}}
+    assert _diff_children(same, dict(same)) is None
+
+
+# ---------------- BridgeClient 协议往返 ----------------
+
+class _EchoHandler(socketserver.StreamRequestHandler):
+    captured = None
+
+    def handle(self):
+        line = self.rfile.readline()
+        req = json.loads(line.decode("utf-8"))
+        type(self).captured = req
+        reply = self.server.reply_fn(req)
+        self.wfile.write((json.dumps(reply) + "\n").encode("utf-8"))
+
+
+class _MockServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+@pytest.fixture
+def mock_bridge():
+    """启一个本地 mock bridge，reply_fn 决定回什么。返回 (client, set_reply, get_request)。"""
+    server = _MockServer(("127.0.0.1", 0), _EchoHandler)
+    server.reply_fn = lambda req: {"id": req.get("id"), "success": True, "result": {"echo": True}}
+    th = threading.Thread(target=server.serve_forever, daemon=True)
+    th.start()
+    host, port = server.server_address
+    client = BridgeClient(host=host, port=port, connect_timeout=2.0, request_timeout=2.0)
+    yield client, server, _EchoHandler
+    server.shutdown()
+
+
+def test_request_roundtrip_and_framing(mock_bridge):
+    client, server, handler = mock_bridge
+    result = client.request("execute_tool", {"name": "create_node", "args": {"x": 1}})
+    assert result == {"echo": True}
+    # 校验客户端发出的报文结构
+    req = handler.captured
+    assert req["action"] == "execute_tool"
+    assert req["payload"] == {"name": "create_node", "args": {"x": 1}}
+    assert isinstance(req["id"], str) and req["id"]
+
+
+def test_execute_tool_helper(mock_bridge):
+    client, server, handler = mock_bridge
+    server.reply_fn = lambda req: {"id": req["id"], "success": True,
+                                   "result": {"success": True, "name": req["payload"]["name"]}}
+    out = client.execute_tool("save_hip", {"path": "/tmp/x.hip"})
+    assert out["name"] == "save_hip"
+
+
+def test_server_error_raises(mock_bridge):
+    client, server, handler = mock_bridge
+    server.reply_fn = lambda req: {"success": False, "error": "boom"}
+    with pytest.raises(RuntimeError, match="boom"):
+        client.request("execute_tool", {"name": "bad"})
+
+
+def test_ping_returns_none_when_unreachable():
+    # 指向一个没人监听的端口，ping 应静默返回 None
+    client = BridgeClient(host="127.0.0.1", port=1, connect_timeout=0.2)
+    assert client.ping() is None

--- a/tests/test_meshy_config.py
+++ b/tests/test_meshy_config.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""Meshy API Key 解析/脱敏/读写测试。"""
+import os
+
+from houdini_agent.meshy import config as c
+from shared import common_utils as cu
+
+
+def test_no_key_by_default():
+    assert c.get_api_key() is None
+    assert c.has_api_key() is False
+    assert c.masked_key() == ""
+
+
+def test_env_var_takes_precedence(monkeypatch):
+    cu.save_config("ai", {"meshy_api_key": "ini_key_xxxx"}, dcc_type="houdini")
+    monkeypatch.setenv("MESHY_API_KEY", "env_key_yyyy")
+    assert c.get_api_key() == "env_key_yyyy"   # env 优先于 ini
+
+
+def test_ini_fallback_when_no_env():
+    cu.save_config("ai", {"meshy_api_key": "ini_key_zzzz"}, dcc_type="houdini")
+    assert c.get_api_key() == "ini_key_zzzz"
+    assert c.has_api_key() is True
+
+
+def test_key_is_stripped():
+    cu.save_config("ai", {"meshy_api_key": "  spaced_key  "}, dcc_type="houdini")
+    assert c.get_api_key() == "spaced_key"
+
+
+def test_set_api_key_persists_to_ini():
+    try:
+        assert c.set_api_key("msy_secret_1234", persist=True)
+        os.environ.pop("MESHY_API_KEY", None)        # 去掉 env 以验证落盘
+        cfg, _ = cu.load_config("ai", dcc_type="houdini")
+        assert cfg.get("meshy_api_key") == "msy_secret_1234"
+    finally:
+        os.environ.pop("MESHY_API_KEY", None)
+
+
+def test_set_api_key_rejects_empty():
+    assert c.set_api_key("", persist=True) is False
+    assert c.set_api_key("   ", persist=True) is False
+
+
+def test_clear_api_key(monkeypatch):
+    cu.save_config("ai", {"meshy_api_key": "to_be_cleared"}, dcc_type="houdini")
+    monkeypatch.setenv("MESHY_API_KEY", "to_be_cleared")
+    c.clear_api_key()
+    assert os.environ.get("MESHY_API_KEY") is None
+    cfg, _ = cu.load_config("ai", dcc_type="houdini")
+    assert "meshy_api_key" not in cfg
+    assert c.get_api_key() is None
+
+
+def test_masked_key_format():
+    cu.save_config("ai", {"meshy_api_key": "msy_1234567890abcd"}, dcc_type="houdini")
+    masked = c.masked_key()
+    assert masked == "msy_" + "*" * 4 + "abcd"
+    assert "1234567890" not in masked     # 中间不泄露
+
+
+def test_masked_short_key_all_stars():
+    cu.save_config("ai", {"meshy_api_key": "short"}, dcc_type="houdini")
+    assert c.masked_key() == "*" * len("short")

--- a/tests/test_meshy_schemas.py
+++ b/tests/test_meshy_schemas.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Meshy 工具 schema 与工具集合的自洽性测试。"""
+from houdini_agent.meshy import schemas as s
+
+
+def _names():
+    return {t["function"]["name"] for t in s.MESHY_TOOLS}
+
+
+def test_all_tools_have_wellformed_schema():
+    for t in s.MESHY_TOOLS:
+        assert t.get("type") == "function"
+        fn = t.get("function") or {}
+        assert isinstance(fn.get("name"), str) and fn["name"]
+        assert isinstance(fn.get("description"), str) and fn["description"]
+        params = fn.get("parameters") or {}
+        assert params.get("type") == "object"
+        assert isinstance(params.get("properties"), dict)
+
+
+def test_tool_names_unique():
+    names = [t["function"]["name"] for t in s.MESHY_TOOLS]
+    assert len(names) == len(set(names))
+
+
+def test_expected_tool_count_and_membership():
+    names = _names()
+    assert names == s.ALL_TOOL_NAMES
+    assert len(names) == 11
+    for expected in ("meshy_text_to_3d", "meshy_image_to_3d", "meshy_text_to_image",
+                     "meshy_image_to_image", "meshy_concept_to_3d", "meshy_retexture",
+                     "meshy_remesh", "meshy_balance", "meshy_task_status",
+                     "import_3d_asset", "export_node_to_glb"):
+        assert expected in names
+
+
+def test_category_sets_are_subsets_of_all():
+    for category in (s.NETWORK_TOOLS, s.INTERACTIVE_TOOLS, s.HOUDINI_TOOLS,
+                     s.CONFIRM_TOOLS, s.MUTATING_TOOLS):
+        assert category <= s.ALL_TOOL_NAMES
+
+
+def test_network_and_houdini_tools_disjoint():
+    # 网络工具(app 侧)与 Houdini 工具(主线程)不应重叠
+    assert not (s.NETWORK_TOOLS & s.HOUDINI_TOOLS)
+
+
+def test_interactive_tools_are_network_tools():
+    # 交互工具都属于网络工具(都要烧 credits、走 app 侧)
+    assert s.INTERACTIVE_TOOLS <= s.NETWORK_TOOLS
+
+
+def test_confirm_tools_exclude_free_ones():
+    # balance / task_status 免费，不应进确认门
+    assert "meshy_balance" not in s.CONFIRM_TOOLS
+    assert "meshy_task_status" not in s.CONFIRM_TOOLS
+
+
+def test_houdini_tools_exact():
+    assert s.HOUDINI_TOOLS == frozenset({"import_3d_asset", "export_node_to_glb"})

--- a/tests/test_meshy_telemetry.py
+++ b/tests/test_meshy_telemetry.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""Meshy 用量埋点：事件构建、spool 往返、去重、opt-out、安装 ID、上传。"""
+import json
+import os
+
+from shared import common_utils as cu
+
+
+def _read_spool_lines(t):
+    path = t._spool_path()
+    if not os.path.isfile(path):
+        return []
+    with open(path, encoding="utf-8") as f:
+        return [ln for ln in f.read().splitlines() if ln.strip()]
+
+
+def test_build_event_shape(telemetry_mod):
+    t = telemetry_mod
+    ev = t._build_event("text-to-3d", {"id": "task42", "consumed_credits": 5,
+                                       "prompt": "a rock", "ai_model": "m", "mode": "preview"})
+    assert ev["kind"] == "text-to-3d"
+    assert ev["task_id"] == "task42"
+    assert ev["credits"] == 5
+    assert ev["prompt"] == "a rock"
+    assert ev["status"] == "SUCCEEDED"
+    assert len(ev["event_id"]) == 32          # uuid4 hex
+    assert ev["install_id"]
+
+
+def test_build_event_credits_coerced(telemetry_mod):
+    ev = telemetry_mod._build_event("remesh", {"id": "x", "consumed_credits": None})
+    assert ev["credits"] == 0
+    ev2 = telemetry_mod._build_event("remesh", {"id": "y", "consumed_credits": "bad"})
+    assert ev2["credits"] == 0
+
+
+def test_prompt_truncated(telemetry_mod):
+    long = "z" * 5000
+    ev = telemetry_mod._build_event("text-to-image", {"id": "p", "prompt": long})
+    assert len(ev["prompt"]) == telemetry_mod._PROMPT_MAX
+
+
+def test_install_id_stable_and_persisted(telemetry_mod):
+    a = telemetry_mod.install_id()
+    telemetry_mod._install_id_cache[0] = None      # 清缓存，强制从 ini 再读
+    b = telemetry_mod.install_id()
+    assert a == b
+    cfg, _ = cu.load_config("ai", dcc_type="houdini")
+    assert cfg.get("telemetry_install_id") == a
+
+
+def test_is_enabled_default_true(telemetry_mod):
+    assert telemetry_mod.is_enabled() is True
+
+
+def test_is_enabled_env_optout(telemetry_mod, monkeypatch):
+    monkeypatch.setenv("HAGENT_TELEMETRY_OFF", "1")
+    assert telemetry_mod.is_enabled() is False
+
+
+def test_is_enabled_ini_optout(telemetry_mod):
+    assert telemetry_mod.set_optout(True)
+    assert telemetry_mod.is_enabled() is False
+    assert telemetry_mod.set_optout(False)
+    assert telemetry_mod.is_enabled() is True
+
+
+def test_record_task_writes_spool(telemetry_mod):
+    telemetry_mod.record_task("text-to-3d", {"id": "t1", "consumed_credits": 3, "prompt": "hi"})
+    lines = _read_spool_lines(telemetry_mod)
+    assert len(lines) == 1
+    ev = json.loads(lines[0])
+    assert ev["task_id"] == "t1" and ev["credits"] == 3
+
+
+def test_record_task_dedups_same_task(telemetry_mod):
+    for _ in range(3):
+        telemetry_mod.record_task("text-to-3d", {"id": "dup", "consumed_credits": 1})
+    assert len(_read_spool_lines(telemetry_mod)) == 1     # 同 task 只入账一次
+
+
+def test_record_task_optout_writes_nothing(telemetry_mod, monkeypatch):
+    monkeypatch.setenv("HAGENT_TELEMETRY_OFF", "1")
+    telemetry_mod.record_task("text-to-3d", {"id": "t2", "consumed_credits": 9})
+    assert _read_spool_lines(telemetry_mod) == []
+
+
+def test_flush_once_uploads_and_clears(telemetry_mod):
+    telemetry_mod.record_task("text-to-3d", {"id": "a", "consumed_credits": 1})
+    telemetry_mod.record_task("image-to-3d", {"id": "b", "consumed_credits": 2})
+    sent, remaining = telemetry_mod.flush_once()
+    assert sent == 2 and remaining == 0
+    assert _read_spool_lines(telemetry_mod) == []          # 上传成功后 spool 清空
+    # _post 被捕获：一批两条
+    assert telemetry_mod.posted and len(telemetry_mod.posted[0][1]) == 2
+
+
+def test_flush_once_failure_keeps_spool(telemetry_mod, monkeypatch):
+    telemetry_mod.record_task("text-to-3d", {"id": "c", "consumed_credits": 1})
+    monkeypatch.setattr(telemetry_mod, "_post", lambda url, events: False)   # 模拟上传失败
+    sent, remaining = telemetry_mod.flush_once()
+    assert sent == 0 and remaining == 1
+    assert len(_read_spool_lines(telemetry_mod)) == 1       # 失败原样保留
+
+
+def test_local_pending_summary(telemetry_mod):
+    telemetry_mod.record_task("text-to-3d", {"id": "a", "consumed_credits": 4})
+    telemetry_mod.record_task("remesh", {"id": "b", "consumed_credits": 6})
+    summ = telemetry_mod.local_pending_summary()
+    assert summ["pending"] == 2
+    assert summ["pending_credits"] == 10

--- a/tests/test_shared_config.py
+++ b/tests/test_shared_config.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""shared.common_utils 的配置/历史读写测试（已隔离到临时目录）。"""
+import os
+
+from shared import common_utils as cu
+
+
+def test_save_and_load_roundtrip():
+    ok, path = cu.save_config("ai", {"k1": "v1", "k2": "v2"}, dcc_type="houdini")
+    assert ok
+    assert os.path.basename(path) == "houdini_ai.ini"
+    cfg, p2 = cu.load_config("ai", dcc_type="houdini")
+    assert cfg["k1"] == "v1"
+    assert cfg["k2"] == "v2"
+    assert p2 == path
+
+
+def test_load_missing_returns_empty():
+    cfg, path = cu.load_config("does_not_exist", dcc_type="houdini")
+    assert cfg == {}
+    assert path.endswith("houdini_does_not_exist.ini")
+
+
+def test_value_may_contain_colon():
+    # 实现按第一个冒号切分，URL 之类带冒号的值应完整保留
+    cu.save_config("ai", {"url": "https://x.y/z"}, dcc_type="houdini")
+    cfg, _ = cu.load_config("ai", dcc_type="houdini")
+    assert cfg["url"] == "https://x.y/z"
+
+
+def test_config_dir_is_isolated(tmp_path):
+    # 隔离夹具应把 config 目录指到临时根下，绝不落在真实仓库
+    d = cu.get_config_dir()
+    assert "repo" in d and str(tmp_path) in d
+
+
+def test_history_roundtrip():
+    assert cu.add_to_history("chat", "hello", dcc_type="houdini")
+    rows = cu.load_history("chat", dcc_type="houdini")
+    assert rows and rows[0][0] == "hello"

--- a/tests/test_telemetry_server.py
+++ b/tests/test_telemetry_server.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""埋点接收后端：去重入库、统计聚合，以及 HTTP 端到端。"""
+import http.client
+import importlib.util
+import json
+import threading
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+_SERVER_PY = Path(__file__).resolve().parents[1] / "deploy" / "telemetry_server" / "server.py"
+
+
+def _load_server(db_path):
+    spec = importlib.util.spec_from_file_location("ha_telemetry_server", _SERVER_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    mod.DB_PATH = str(db_path)          # 重定向到临时库（函数读模块全局 DB_PATH）
+    mod._init_db()
+    return mod
+
+
+@pytest.fixture
+def srv(tmp_path):
+    return _load_server(tmp_path / "telemetry.db")
+
+
+def _ev(eid, install="i1", kind="text-to-3d", credits=5):
+    return {"event_id": eid, "install_id": install, "ts": 1, "version": "2.0.0",
+            "kind": kind, "task_id": "t", "ai_model": "m", "mode": "preview",
+            "status": "SUCCEEDED", "credits": credits, "prompt": "p"}
+
+
+def test_ingest_counts_new_rows(srv):
+    assert srv._ingest([_ev("e1"), _ev("e2")]) == 2
+
+
+def test_ingest_dedups_by_event_id(srv):
+    srv._ingest([_ev("e1")])
+    assert srv._ingest([_ev("e1"), _ev("e3")]) == 1     # e1 已存在，只新增 e3
+
+
+def test_ingest_skips_missing_event_id(srv):
+    assert srv._ingest([{"install_id": "x", "credits": 1}]) == 0
+
+
+def test_ingest_coerces_bad_credits(srv):
+    srv._ingest([{"event_id": "e9", "credits": "oops"}])
+    assert srv._stats()["total_credits"] == 0
+
+
+def test_stats_aggregation(srv):
+    srv._ingest([
+        _ev("a", install="i1", kind="text-to-3d", credits=10),
+        _ev("b", install="i1", kind="text-to-3d", credits=5),
+        _ev("c", install="i2", kind="remesh", credits=2),
+    ])
+    st = srv._stats()
+    assert st["total_credits"] == 17
+    assert st["total_events"] == 3
+    assert st["distinct_installs"] == 2
+    assert st["by_kind"]["text-to-3d"] == {"events": 2, "credits": 15}
+    assert st["by_kind"]["remesh"] == {"events": 1, "credits": 2}
+
+
+# ---------------- HTTP 端到端 ----------------
+
+@pytest.fixture
+def http_srv(srv):
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), srv.Handler)
+    th = threading.Thread(target=httpd.serve_forever, daemon=True)
+    th.start()
+    yield srv, httpd.server_address
+    httpd.shutdown()
+
+
+def _conn(addr):
+    return http.client.HTTPConnection(addr[0], addr[1], timeout=5)
+
+
+def test_http_health(http_srv):
+    _, addr = http_srv
+    c = _conn(addr); c.request("GET", "/api/health")
+    r = c.getresponse()
+    assert r.status == 200
+    assert json.loads(r.read())["ok"] is True
+
+
+def test_http_post_and_stats(http_srv):
+    _, addr = http_srv
+    body = json.dumps({"events": [_ev("h1", credits=7), _ev("h2", credits=3)]})
+    c = _conn(addr)
+    c.request("POST", "/api/telemetry", body=body,
+              headers={"Content-Type": "application/json"})
+    r = c.getresponse()
+    assert r.status == 200
+    out = json.loads(r.read())
+    assert out["ok"] is True and out["accepted"] == 2
+
+    c2 = _conn(addr); c2.request("GET", "/api/telemetry/stats")
+    st = json.loads(c2.getresponse().read())
+    assert st["total_credits"] == 10 and st["total_events"] == 2
+
+
+def test_http_rejects_bad_json(http_srv):
+    _, addr = http_srv
+    c = _conn(addr)
+    c.request("POST", "/api/telemetry", body="{not json",
+              headers={"Content-Type": "application/json"})
+    assert c.getresponse().status == 400
+
+
+def test_http_unknown_path_404(http_srv):
+    _, addr = http_srv
+    c = _conn(addr); c.request("GET", "/nope")
+    assert c.getresponse().status == 404

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""ToolRegistry：注册、模式访问控制、标签、启用/禁用。"""
+import pytest
+
+from houdini_agent.utils.tool_registry import ToolRegistry, get_tool_registry
+
+
+def _schema(name):
+    return {"type": "function",
+            "function": {"name": name, "description": "d",
+                         "parameters": {"type": "object", "properties": {}}}}
+
+
+@pytest.fixture
+def reg():
+    # 用独立实例，避免污染全局单例
+    return ToolRegistry()
+
+
+def test_register_and_mode_guard(reg):
+    reg.register("foo", _schema("foo"), modes={"agent"}, tags={"meshy"})
+    assert reg.is_tool_allowed_in_mode("foo", "agent") is True
+    assert reg.is_tool_allowed_in_mode("foo", "ask") is False
+    assert reg.is_tool_allowed_in_mode("missing", "agent") is False
+
+
+def test_get_tools_for_mode_only_enabled(reg):
+    reg.register("a", _schema("a"), modes={"agent"})
+    reg.register("b", _schema("b"), modes={"ask"})
+    agent_names = {t["function"]["name"] for t in reg.get_tools_for_mode("agent")}
+    assert "a" in agent_names and "b" not in agent_names
+
+
+def test_disable_blocks_tool(reg):
+    reg.register("c", _schema("c"), modes={"agent"})
+    assert reg.is_tool_allowed_in_mode("c", "agent")
+    reg.set_enabled("c", False)
+    assert reg.is_tool_allowed_in_mode("c", "agent") is False
+
+
+def test_unregister(reg):
+    reg.register("d", _schema("d"), modes={"agent"})
+    reg.unregister("d")
+    assert reg.is_tool_allowed_in_mode("d", "agent") is False
+
+
+def test_unregister_by_source(reg):
+    reg.register("p1", _schema("p1"), source="plugin", plugin_name="P", modes={"agent"})
+    reg.register("core1", _schema("core1"), source="core", modes={"agent"})
+    reg.unregister_by_source("plugin", "P")
+    assert "p1" not in reg._tools
+    assert "core1" in reg._tools
+
+
+def test_get_tool_registry_is_singleton():
+    assert get_tool_registry() is get_tool_registry()


### PR DESCRIPTION
为 v2.0 新增**离线自动化测试系统**:57 个单元测试,完全离线——不需要 Houdini(hou)、不需要 API Key、不发任何网络请求。

## 内容
- **基础设施**:`pytest.ini` + `tests/conftest.py`
  - 路径隔离:把 `shared.common_utils.get_repo_root` 重定向到临时目录,config/cache 读写绝不碰真实文件
  - 环境隔离 + `_post` 打桩禁网 + 最小 `hou` 桩兜底
- **CI**:`.github/workflows/tests.yml`,push/PR 自动跑 pytest(Python 3.11–3.13)
- **覆盖**:shared 配置、meshy config/schemas/telemetry、telemetry_server(含 HTTP 端到端)、tool_registry、bridge 协议

## 本地结果
`57 passed in ~4s`

## 尚未覆盖(需 Houdini 运行时,后续补)
`hou.*` 节点操作、QML UI、Meshy 真实 API、controller 信号流。

🤖 Generated with [Claude Code](https://claude.com/claude-code)