### PR TITLE
fix(updater): 修复打包后当前版本误报 0.0.0

### DIFF
--- a/houdini_agent/ui_qml/controller.py
+++ b/houdini_agent/ui_qml/controller.py
@@ -1431,7 +1431,7 @@ class Controller(QObject):
                             "发现新版本：%s\n"
                             "当前版本：%s\n\n"
                             "%s\n\n"
-                            "自动下载应用暂未接入 QML 面板，请先使用测试环境验证后再更新正式目录。"
+                            "请到 houdini-agent.com 或 GitHub Releases 下载新版安装包更新。"
                         ) % (r.get("remote_version", "?"), r.get("local_version", "?"), notes)
                     else:
                         msg = "已是最新版本。\n\n当前版本：%s\n最新 Release：%s" % (

--- a/houdini_agent/utils/updater.py
+++ b/houdini_agent/utils/updater.py
@@ -30,6 +30,23 @@ _API_LATEST_RELEASE = f"https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 _VERSION_FILE = _PROJECT_ROOT / "VERSION"
 
+
+def _version_candidates():
+    """可能放置 VERSION 的位置（兼容源码运行与 PyInstaller 打包）。
+    打包后 __file__ 推导未必可靠，需优先用 _MEIPASS / 可执行文件目录兜底。"""
+    roots = []
+    mei = getattr(sys, "_MEIPASS", None)        # PyInstaller：VERSION 打到 _internal 根
+    if mei:
+        roots.append(Path(mei))
+    roots.append(_PROJECT_ROOT)                  # 源码：<repo>/VERSION
+    try:                                         # 独立程序：exe 同级 / exe 下 _internal
+        exe_dir = Path(sys.executable).resolve().parent
+        roots.append(exe_dir)
+        roots.append(exe_dir / "_internal")
+    except Exception:
+        pass
+    return roots
+
 # ETag 缓存文件（用于减少 GitHub API 计数、应对 403 限流）
 _ETAG_CACHE_FILE = _PROJECT_ROOT / "cache" / "update_cache.json"
 
@@ -47,11 +64,18 @@ _PRESERVE_PATHS = frozenset({
 # ==========================================================
 
 def get_local_version() -> str:
-    """读取本地 VERSION 文件，返回版本字符串，失败返回 '0.0.0'"""
-    try:
-        return _VERSION_FILE.read_text(encoding="utf-8").strip()
-    except Exception:
-        return "0.0.0"
+    """读取本地 VERSION 文件，返回版本字符串，失败返回 '0.0.0'。
+    依次尝试多个候选位置，兼容源码运行与打包（避免打包后误报 0.0.0）。"""
+    for root in _version_candidates():
+        try:
+            f = root / "VERSION"
+            if f.is_file():
+                txt = f.read_text(encoding="utf-8").strip()
+                if txt:
+                    return txt
+        except Exception:
+            continue
+    return "0.0.0"
 
 
 def _parse_version(v: str) -> Tuple[int, ...]:

--- a/tests/test_updater_version.py
+++ b/tests/test_updater_version.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""更新器本地版本读取：兼容源码与打包，避免误报 0.0.0。"""
+import sys
+
+from houdini_agent.utils import updater
+
+
+def test_reads_source_version_nonzero():
+    # 源码树下应读到真实 VERSION，绝不是 0.0.0
+    v = updater.get_local_version()
+    assert v and v != "0.0.0"
+
+
+def test_meipass_takes_priority(tmp_path, monkeypatch):
+    # 模拟 PyInstaller：VERSION 在 _MEIPASS 根，应优先命中
+    (tmp_path / "VERSION").write_text("9.9.9\n", encoding="utf-8")
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+    assert updater.get_local_version() == "9.9.9"
+
+
+def test_fallback_zero_when_no_version_anywhere(tmp_path, monkeypatch):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setattr(updater, "_version_candidates", lambda: [empty])
+    assert updater.get_local_version() == "0.0.0"
+
+
+def test_candidates_include_meipass_when_frozen(tmp_path, monkeypatch):
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+    roots = [str(p) for p in updater._version_candidates()]
+    assert str(tmp_path) == roots[0]      # 打包时 _MEIPASS 必须排在最前


### PR DESCRIPTION
## 问题
自动更新检查显示「当前版本：0.0.0」,导致永远提示有更新。

## 根因
`updater.get_local_version()` 用 `Path(__file__)...` 推导 VERSION 路径,PyInstaller 打包后该推导不可靠,读不到 `_internal/VERSION` 即回退 `0.0.0`。

## 修复
- `get_local_version` 改为多候选搜索:优先 `sys._MEIPASS`(打包),再源码根、exe 目录 / `_internal`。
- 更新提示文案改为面向用户(到 houdini-agent.com / GitHub Releases 下载),替换原开发口吻文案。
- 新增 4 个单测覆盖打包/源码/回退路径。

`61 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)