### PR TITLE
fix(ui): 更新提示横幅移到输入框上方

### DIFF
--- a/houdini_agent/ui_qml/qml/Main.qml
+++ b/houdini_agent/ui_qml/qml/Main.qml
@@ -42,13 +42,22 @@ Rectangle {
         Layout.fillHeight: true
         spacing: 0
 
-        // update notification banner
+        Header      { Layout.fillWidth: true }
+        SessionTabs { Layout.fillWidth: true }
+        ContextBar  { Layout.fillWidth: true }
+
+        ChatView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+
+        // 更新提示横幅 —— 紧贴输入框上方（沿用 1.5 的“输入区域上方”位置）
         Rectangle {
             Layout.fillWidth: true
             visible: controller && controller.updateText.length > 0
             implicitHeight: visible ? 34 : 0
             color: Theme.accentSoft
-            Rectangle { anchors.bottom: parent.bottom; width: parent.width; height: 1; color: Theme.accentLine }
+            Rectangle { anchors.top: parent.top; width: parent.width; height: 1; color: Theme.accentLine }
             Row {
                 anchors.fill: parent; anchors.leftMargin: 15; anchors.rightMargin: 12; spacing: 8
                 Text {
@@ -65,15 +74,6 @@ Rectangle {
                         onClicked: if (controller) controller.dismissUpdate() }
                 }
             }
-        }
-
-        Header      { Layout.fillWidth: true }
-        SessionTabs { Layout.fillWidth: true }
-        ContextBar  { Layout.fillWidth: true }
-
-        ChatView {
-            Layout.fillWidth: true
-            Layout.fillHeight: true
         }
 
         Composer { Layout.fillWidth: true }


### PR DESCRIPTION
把 2.0 QML 的更新通知横幅从窗口顶部移到 Composer(输入框)上方,还原 1.5.x「输入区域上方」的位置。启动静默检测已有(app.py/external_app.py 4s 后触发),横幅 visible 绑定 controller.updateText。

🤖 Generated with [Claude Code](https://claude.com/claude-code)