### PR TITLE
chore(website): bump displayed version to 2.0.4

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -636,7 +636,7 @@ footer{border-top:1px solid var(--border);padding:54px 0 40px;margin-top:30px}
           <a class="btn solid" href="#download"><span class="zh">立即下载</span><span class="en">Download</span></a>
           <a class="btn" href="#generation"><span class="zh">看 3D 生成</span><span class="en">See 3D gen</span></a>
           <a class="btn meshy js-meshy-api" href="https://www.meshy.ai/settings/api" target="_blank" rel="noopener"><img class="meshy-ico" src="assets/meshy-logo.svg" alt="" /><span class="zh">获取 Meshy API Key</span><span class="en">Get Meshy key</span></a>
-          <span class="ver">v2.0.3</span>
+          <span class="ver">v2.0.4</span>
         </div>
         <div class="hero-stats">
           <div class="hstat"><div class="n"><em class="cnt" data-to="50">0</em>+</div><div class="l"><span class="zh">内置工具</span><span class="en">Built-in tools</span></div></div>
@@ -1484,10 +1484,10 @@ launcher.<span class="fn">show_tool</span>()  <span class="com"># 在 Houdini �
     <div class="sec-head reveal">
       <div class="kicker"><span class="ln"></span><span class="ml accent">11 — Changelog</span></div>
       <h2><span class="zh">持续<em>迭代</em>。</span><span class="en">Shipping, <em>continuously</em>.</span></h2>
-      <p><span class="zh">当前版本 v2.0.3。从初版原型，到 50+ 工具、能生成 3D 资产的自主 Agent，一直在更新。</span><span class="en">Currently v2.0.3. From the first prototype to a 50+ tool autonomous agent that generates 3D assets — and still moving.</span></p>
+      <p><span class="zh">当前版本 v2.0.4。从初版原型，到 50+ 工具、能生成 3D 资产的自主 Agent，一直在更新。</span><span class="en">Currently v2.0.4. From the first prototype to a 50+ tool autonomous agent that generates 3D assets — and still moving.</span></p>
     </div>
     <div class="timeline" data-stagger>
-      <div class="tl now"><div class="tlv">v2.0.3</div><div class="tlt"><span class="zh">Meshy AI 3D 生成 · QML 新界面</span><span class="en">Meshy AI 3D · new QML UI</span></div><div class="tld"><span class="zh">深度集成 Meshy：文生 / 图生 3D、概念图画廊、图生图二次编辑、云资产库与账号同步、后台任务；前端用 QML / Qt Quick 全面重写。</span><span class="en">Deep Meshy integration: text/image-to-3D, concept galleries, image-to-image editing, a cloud asset library with account sync, and background tasks; the frontend fully rewritten in QML / Qt Quick.</span></div></div>
+      <div class="tl now"><div class="tlv">v2.0.4</div><div class="tlt"><span class="zh">Meshy AI 3D 生成 · QML 新界面</span><span class="en">Meshy AI 3D · new QML UI</span></div><div class="tld"><span class="zh">深度集成 Meshy：文生 / 图生 3D、概念图画廊、图生图二次编辑、云资产库与账号同步、后台任务；前端用 QML / Qt Quick 全面重写。</span><span class="en">Deep Meshy integration: text/image-to-3D, concept galleries, image-to-image editing, a cloud asset library with account sync, and background tasks; the frontend fully rewritten in QML / Qt Quick.</span></div></div>
       <div class="tl"><div class="tlv">v1.5</div><div class="tlt"><span class="zh">DeepSeek V4 · 记忆管理器</span><span class="en">DeepSeek V4 · memory manager</span></div><div class="tld"><span class="zh">DeepSeek V4 适配 + JSON Output、记忆管理器对话框、长期记忆全局开关。</span><span class="en">DeepSeek V4 + JSON output, a memory-manager dialog, and a global long-term-memory toggle.</span></div></div>
       <div class="tl"><div class="tlv">v1.5.0</div><div class="tlt"><span class="zh">自定义提供商 + 视口截图</span><span class="en">Custom provider + viewport capture</span></div><div class="tld"><span class="zh">接入任意 OpenAI 兼容端点；新增 capture_viewport 把 3D 视口喂给视觉模型。</span><span class="en">Any OpenAI-compatible endpoint; capture_viewport feeds the 3D viewport to vision models.</span></div></div>
       <div class="tl"><div class="tlv">v1.4.0</div><div class="tlt">OpenRouter</div><div class="tld"><span class="zh">单一 API Key 接入 16 个主流模型（Claude / GPT / Gemini / Grok / Llama / Qwen…）。</span><span class="en">16 mainstream models behind one API key (Claude / GPT / Gemini / Grok / Llama / Qwen…).</span></div></div>
@@ -1544,7 +1544,7 @@ launcher.<span class="fn">show_tool</span>()  <span class="com"># 在 Houdini �
     <div class="dl reveal">
       <h2><span class="zh">把 AI 装进<em>你的节点网络</em>。</span><span class="en">Put AI <em>in your node graph</em>.</span></h2>
       <p><span class="zh">免费、开源。下载独立程序，自动连接 Houdini —— 无需配置 Python。建网、写 VEX、生成 3D 资产，全在一句话之间。</span><span class="en">Free and open source. Download the standalone app — it connects to Houdini, no Python setup. Build networks, write VEX, generate 3D assets — all a sentence away.</span></p>
-      <div class="reqline">v2.0.3 · Houdini 20.5+ / 21+ · Windows · macOS · Linux · MIT</div>
+      <div class="reqline">v2.0.4 · Houdini 20.5+ / 21+ · Windows · macOS · Linux · MIT</div>
       <div class="dl-cta">
         <a class="btn solid" id="dlBtn" href="/download/HoudiniAgent-Setup.exe" download><span class="zh">下载安装程序</span><span class="en">Download installer</span></a>
         <a class="btn" href="https://github.com/Kazama-Suichiku/Houdini-Agent/releases" target="_blank" rel="noopener"><span class="zh">所有版本</span><span class="en">All releases</span></a>


### PR DESCRIPTION
Bumps the site's displayed version to v2.0.4 to match the released installer. Requirements line left at Houdini 20.5+/21+ (19.5 support ships in 2.0.4 but is not advertised on the site until verified on real 19.5 hardware).