### PR TITLE
docs(site): 官网 + 下载页更新到 2.0.6

### DIFF
--- a/website/downloads/index.html
+++ b/website/downloads/index.html
@@ -86,6 +86,18 @@ footer a:hover{color:var(--accent)}
 
     <article class="rel latest">
       <div class="top">
+        <span class="ver">v2.0.6</span>
+        <span class="meta">2026-06-18 · Windows x64 · ~71 MB</span>
+      </div>
+      <p class="desc">新增角色绑定与动画：人形角色一键自动绑骨蒙皮，从约 600 个预设动作里检索套用，经典 FBX 导入 Houdini（骨架 + 蒙皮 + 关键帧，可直接播放）。含 2.0.5 的断连识别与文件版本信息。</p>
+      <div class="cta">
+        <a class="dl" href="/download/HoudiniAgent-Setup-2.0.6.exe" download>下载 v2.0.6 · Download</a>
+        <a class="sub" href="https://github.com/Kazama-Suichiku/Houdini-Agent/releases/tag/v2.0.6" target="_blank" rel="noopener">发行说明 · Release notes</a>
+      </div>
+    </article>
+
+    <article class="rel">
+      <div class="top">
         <span class="ver">v2.0.5</span>
         <span class="meta">2026-06-17 · Windows x64 · ~72 MB</span>
       </div>

--- a/website/index.html
+++ b/website/index.html
@@ -629,18 +629,18 @@ footer{border-top:1px solid var(--border);padding:54px 0 40px;margin-top:30px}
           <span class="en">An AI assistant for Houdini. An <b>autonomous agent loop</b> reads your network, creates and wires nodes, writes VEX, runs Python — now with <b>Meshy AI 3D generation</b>: from a sentence to textured 3D assets, dropped straight into your node graph.</span>
         </p>
         <p class="sub">
-          <span class="zh">50+ 工具 · 文生/图生 3D · 概念图画廊 · 图生图二次编辑 · 云资产库 · 后台任务 · 六大 AI 提供商 · Plan 模式 · 长期记忆 · 全新 QML 界面 · 中英双语。独立程序自带运行环境，自动桥接到 Houdini。</span>
-          <span class="en">50+ tools · text/image-to-3D · concept galleries · image-to-image editing · cloud asset library · background tasks · six AI providers · Plan mode · long-term memory · new QML UI · bilingual. A standalone app with its own runtime, auto-bridged to Houdini.</span>
+          <span class="zh">50+ 工具 · 文生/图生 3D · 角色绑定与动画 · 概念图画廊 · 图生图二次编辑 · 云资产库 · 后台任务 · 六大 AI 提供商 · Plan 模式 · 长期记忆 · 全新 QML 界面 · 中英双语。独立程序自带运行环境，自动桥接到 Houdini。</span>
+          <span class="en">50+ tools · text/image-to-3D · character rigging & animation · concept galleries · image-to-image editing · cloud asset library · background tasks · six AI providers · Plan mode · long-term memory · new QML UI · bilingual. A standalone app with its own runtime, auto-bridged to Houdini.</span>
         </p>
         <div class="hero-cta">
           <a class="btn solid" href="#download"><span class="zh">立即下载</span><span class="en">Download</span></a>
           <a class="btn" href="#generation"><span class="zh">看 3D 生成</span><span class="en">See 3D gen</span></a>
           <a class="btn meshy js-meshy-api" href="https://www.meshy.ai/settings/api" target="_blank" rel="noopener"><img class="meshy-ico" src="assets/meshy-logo.svg" alt="" /><span class="zh">获取 Meshy API Key</span><span class="en">Get Meshy key</span></a>
-          <span class="ver">v2.0.5</span>
+          <span class="ver">v2.0.6</span>
         </div>
         <div class="hero-stats">
           <div class="hstat"><div class="n"><em class="cnt" data-to="50">0</em>+</div><div class="l"><span class="zh">内置工具</span><span class="en">Built-in tools</span></div></div>
-          <div class="hstat"><div class="n"><span class="cnt" data-to="11">0</span></div><div class="l"><span class="zh">3D 生成工具</span><span class="en">3D-gen tools</span></div></div>
+          <div class="hstat"><div class="n"><span class="cnt" data-to="15">0</span></div><div class="l"><span class="zh">3D 生成工具</span><span class="en">3D-gen tools</span></div></div>
           <div class="hstat"><div class="n"><span class="cnt" data-to="6">0</span></div><div class="l"><span class="zh">AI 提供商</span><span class="en">AI providers</span></div></div>
           <div class="hstat"><div class="n"><span class="cnt" data-to="3">0</span></div><div class="l"><span class="zh">运行模式</span><span class="en">Run modes</span></div></div>
         </div>
@@ -1484,10 +1484,11 @@ launcher.<span class="fn">show_tool</span>()  <span class="com"># 在 Houdini �
     <div class="sec-head reveal">
       <div class="kicker"><span class="ln"></span><span class="ml accent">11 — Changelog</span></div>
       <h2><span class="zh">持续<em>迭代</em>。</span><span class="en">Shipping, <em>continuously</em>.</span></h2>
-      <p><span class="zh">当前版本 v2.0.5。从初版原型，到 50+ 工具、能生成 3D 资产的自主 Agent，一直在更新。</span><span class="en">Currently v2.0.5. From the first prototype to a 50+ tool autonomous agent that generates 3D assets — and still moving.</span></p>
+      <p><span class="zh">当前版本 v2.0.6。从初版原型，到 50+ 工具、能生成并绑定/动画 3D 角色的自主 Agent，一直在更新。</span><span class="en">Currently v2.0.6. From the first prototype to a 50+ tool autonomous agent that generates, rigs and animates 3D characters — and still moving.</span></p>
     </div>
     <div class="timeline" data-stagger>
-      <div class="tl now"><div class="tlv">v2.0.5</div><div class="tlt"><span class="zh">Meshy AI 3D 生成 · QML 新界面</span><span class="en">Meshy AI 3D · new QML UI</span></div><div class="tld"><span class="zh">深度集成 Meshy：文生 / 图生 3D、概念图画廊、图生图二次编辑、云资产库与账号同步、后台任务；前端用 QML / Qt Quick 全面重写。</span><span class="en">Deep Meshy integration: text/image-to-3D, concept galleries, image-to-image editing, a cloud asset library with account sync, and background tasks; the frontend fully rewritten in QML / Qt Quick.</span></div></div>
+      <div class="tl now"><div class="tlv">v2.0.6</div><div class="tlt"><span class="zh">角色绑定与动画</span><span class="en">Character rigging & animation</span></div><div class="tld"><span class="zh">接入 Meshy 自动绑定 / 动画：人形角色一键绑骨蒙皮，从约 600 个预设动作里检索套用，经典 FBX 导入 Houdini（骨架 + 蒙皮 + 关键帧，可直接播放）。</span><span class="en">Meshy auto-rigging & animation: one-click skeleton/skin for humanoid characters, pick from ~600 preset actions, classic FBX import into Houdini (skeleton + skin + keyframes, plays in-viewport).</span></div></div>
+      <div class="tl"><div class="tlv">v2.0.5</div><div class="tlt"><span class="zh">Meshy AI 3D 生成 · QML 新界面</span><span class="en">Meshy AI 3D · new QML UI</span></div><div class="tld"><span class="zh">深度集成 Meshy：文生 / 图生 3D、概念图画廊、图生图二次编辑、云资产库与账号同步、后台任务；前端用 QML / Qt Quick 全面重写。</span><span class="en">Deep Meshy integration: text/image-to-3D, concept galleries, image-to-image editing, a cloud asset library with account sync, and background tasks; the frontend fully rewritten in QML / Qt Quick.</span></div></div>
       <div class="tl"><div class="tlv">v1.5</div><div class="tlt"><span class="zh">DeepSeek V4 · 记忆管理器</span><span class="en">DeepSeek V4 · memory manager</span></div><div class="tld"><span class="zh">DeepSeek V4 适配 + JSON Output、记忆管理器对话框、长期记忆全局开关。</span><span class="en">DeepSeek V4 + JSON output, a memory-manager dialog, and a global long-term-memory toggle.</span></div></div>
       <div class="tl"><div class="tlv">v1.5.0</div><div class="tlt"><span class="zh">自定义提供商 + 视口截图</span><span class="en">Custom provider + viewport capture</span></div><div class="tld"><span class="zh">接入任意 OpenAI 兼容端点；新增 capture_viewport 把 3D 视口喂给视觉模型。</span><span class="en">Any OpenAI-compatible endpoint; capture_viewport feeds the 3D viewport to vision models.</span></div></div>
       <div class="tl"><div class="tlv">v1.4.0</div><div class="tlt">OpenRouter</div><div class="tld"><span class="zh">单一 API Key 接入 16 个主流模型（Claude / GPT / Gemini / Grok / Llama / Qwen…）。</span><span class="en">16 mainstream models behind one API key (Claude / GPT / Gemini / Grok / Llama / Qwen…).</span></div></div>
@@ -1544,7 +1545,7 @@ launcher.<span class="fn">show_tool</span>()  <span class="com"># 在 Houdini �
     <div class="dl reveal">
       <h2><span class="zh">把 AI 装进<em>你的节点网络</em>。</span><span class="en">Put AI <em>in your node graph</em>.</span></h2>
       <p><span class="zh">免费、开源。下载独立程序，自动连接 Houdini —— 无需配置 Python。建网、写 VEX、生成 3D 资产，全在一句话之间。</span><span class="en">Free and open source. Download the standalone app — it connects to Houdini, no Python setup. Build networks, write VEX, generate 3D assets — all a sentence away.</span></p>
-      <div class="reqline">v2.0.5 · Houdini 20.5+ / 21+ · Windows · macOS · Linux · MIT</div>
+      <div class="reqline">v2.0.6 · Houdini 19.5+ (经 Bridge) / 21+ · Windows · macOS · Linux · MIT</div>
       <div class="dl-cta">
         <a class="btn solid" id="dlBtn" href="/download/HoudiniAgent-Setup.exe" download><span class="zh">下载安装程序</span><span class="en">Download installer</span></a>
         <a class="btn" href="/downloads/"><span class="zh">所有版本</span><span class="en">All versions</span></a>


### PR DESCRIPTION
首页 + 下载页同步 2.0.6（角色绑定与动画）。配合 GitHub release v2.0.6 与安装包上线。

🤖 Generated with [Claude Code](https://claude.com/claude-code)