### PR TITLE
docs(site): 下载页补齐 v2.0.9 至 v2.0.15

### DIFF
--- a/website/downloads/index.html
+++ b/website/downloads/index.html
@@ -86,6 +86,90 @@ footer a:hover{color:var(--accent)}
 
     <article class="rel latest">
       <div class="top">
+        <span class="ver">v2.0.15</span>
+        <span class="meta">2026-09-04 · Windows x64 · ~71 MB</span>
+      </div>
+      <p class="desc">模型阵容对齐：拼好饭中转按实时清单换上 Claude Opus 5 / Sonnet 5 / Opus 4.8、GPT-5.6 Sol / Terra / Luna、GPT-5.5、GLM-5.3 系列、Grok 4.6 / 4.5、DeepSeek V4；OpenRouter 更新 16 个模型；OpenAI 直连切到 GPT-5.6 系列；DeepSeek 去掉已下线旧模型。上下文上限、视觉能力与计费表同步，修复 OpenRouter 费用统计按默认价的问题。</p>
+      <div class="cta">
+        <a class="dl" href="/download/HoudiniAgent-Setup-2.0.15.exe" download>下载 v2.0.15 · Download</a>
+        <a class="sub" href="https://github.com/Kazama-Suichiku/Houdini-Agent/releases/tag/v2.0.15" target="_blank" rel="noopener">发行说明 · Release notes</a>
+      </div>
+    </article>
+
+    <article class="rel">
+      <div class="top">
+        <span class="ver">v2.0.14</span>
+        <span class="meta">2026-07-12 · Windows x64 · ~71 MB</span>
+      </div>
+      <p class="desc">应用内一键更新：发现新版本时，主界面横幅点「立即更新」即可自动下载、安装并重启，带下载进度，失败可一键重试。含 2.0.12 至 2.0.13 的全部连接修复。</p>
+      <div class="cta">
+        <a class="dl" href="/download/HoudiniAgent-Setup-2.0.14.exe" download>下载 v2.0.14 · Download</a>
+        <a class="sub" href="https://github.com/Kazama-Suichiku/Houdini-Agent/releases/tag/v2.0.14" target="_blank" rel="noopener">发行说明 · Release notes</a>
+      </div>
+    </article>
+
+    <article class="rel">
+      <div class="top">
+        <span class="ver">v2.0.13</span>
+        <span class="meta">2026-07-12 · Windows x64 · ~71 MB</span>
+      </div>
+      <p class="desc">启动脚本热修复：修复 2.0.12 启动脚本在 Houdini 内报错（NameError: __file__）导致 Bridge 无法自启的问题。2.0.12 用户请直接升级。</p>
+      <div class="cta">
+        <a class="dl" href="/download/HoudiniAgent-Setup-2.0.13.exe" download>下载 v2.0.13 · Download</a>
+        <a class="sub" href="https://github.com/Kazama-Suichiku/Houdini-Agent/releases/tag/v2.0.13" target="_blank" rel="noopener">发行说明 · Release notes</a>
+      </div>
+    </article>
+
+    <article class="rel">
+      <div class="top">
+        <span class="ver">v2.0.12</span>
+        <span class="meta">2026-07-12 · Windows x64 · ~71 MB</span>
+      </div>
+      <p class="desc">集成包安装修复：修复「文档」目录被移动 / 重定向（其他盘、OneDrive）时集成包装错位置、Houdini 始终连不上的问题，现在按系统真实文档路径写入全部候选目录；连接自检可直接指出此类问题。</p>
+      <div class="cta">
+        <a class="dl" href="/download/HoudiniAgent-Setup-2.0.12.exe" download>下载 v2.0.12 · Download</a>
+        <a class="sub" href="https://github.com/Kazama-Suichiku/Houdini-Agent/releases/tag/v2.0.12" target="_blank" rel="noopener">发行说明 · Release notes</a>
+      </div>
+    </article>
+
+    <article class="rel">
+      <div class="top">
+        <span class="ver">v2.0.11</span>
+        <span class="meta">2026-07-12 · Windows x64 · ~71 MB</span>
+      </div>
+      <p class="desc">离线可用 · 自动重连 · Agent 连接自检：未连接 Houdini 时聊天、配置 API Key 与 Meshy 生成也完全可用；连接改为常驻心跳，断开自动提示、恢复自动重连，Bridge 换端口自动发现；Agent 新增连接自检与修复工具。</p>
+      <div class="cta">
+        <a class="dl" href="/download/HoudiniAgent-Setup-2.0.11.exe" download>下载 v2.0.11 · Download</a>
+        <a class="sub" href="https://github.com/Kazama-Suichiku/Houdini-Agent/releases/tag/v2.0.11" target="_blank" rel="noopener">发行说明 · Release notes</a>
+      </div>
+    </article>
+
+    <article class="rel">
+      <div class="top">
+        <span class="ver">v2.0.10</span>
+        <span class="meta">2026-07-08 · Windows x64 · ~71 MB</span>
+      </div>
+      <p class="desc">维护性更新：内部维护与稳定性改进，修复若干已知问题。</p>
+      <div class="cta">
+        <a class="dl" href="/download/HoudiniAgent-Setup-2.0.10.exe" download>下载 v2.0.10 · Download</a>
+        <a class="sub" href="https://github.com/Kazama-Suichiku/Houdini-Agent/releases/tag/v2.0.10" target="_blank" rel="noopener">发行说明 · Release notes</a>
+      </div>
+    </article>
+
+    <article class="rel">
+      <div class="top">
+        <span class="ver">v2.0.9</span>
+        <span class="meta">2026-06-29 · Windows x64 · ~71 MB</span>
+      </div>
+      <p class="desc">稳定性修复 · 自定义供应商 · 端口自愈：修复自定义供应商「图片」开关无法开启、重新编辑时模型名丢失、模型过多时保存按钮被挤出；桥接端口被占用时自动顺延并由客户端自动发现，连接探测移至后台线程。</p>
+      <div class="cta">
+        <a class="dl" href="/download/HoudiniAgent-Setup-2.0.9.exe" download>下载 v2.0.9 · Download</a>
+        <a class="sub" href="https://github.com/Kazama-Suichiku/Houdini-Agent/releases/tag/v2.0.9" target="_blank" rel="noopener">发行说明 · Release notes</a>
+      </div>
+    </article>
+
+    <article class="rel">
+      <div class="top">
         <span class="ver">v2.0.8</span>
         <span class="meta">2026-06-22 · Windows x64 · ~71 MB</span>
       </div>


### PR DESCRIPTION
官网「所有版本」页自 2.0.8 后未维护，补齐 2.0.9 到 2.0.15 共 7 个条目，LATEST 标记移到 2.0.15。对应带版本号的安装包已上传到服务器 /download/。

🤖 Generated with [Claude Code](https://claude.com/claude-code)